### PR TITLE
Fixed argument usage in submit_sample_url

### DIFF
--- a/jbxapi.py
+++ b/jbxapi.py
@@ -165,7 +165,7 @@ class JoeSandbox(object):
         """
         self._check_user_parameters(params)
         params = copy.copy(params)
-        params['sample-url'] = sample
+        params['sample-url'] = url
         return self._submit(params)
 
     def submit_url(self, url, params={}):


### PR DESCRIPTION
Argument 'url' was unused, where a non-existing variable 'sample' was referenced within the function, this has been fixed to properly route the url argument.